### PR TITLE
fixing timestamp propogation to influxdb

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,18 +125,18 @@ function processMonitors(monitors){
             const timestamp = moment.unix(rt.datetime);
             responseTimePoints.push({
                 measurement : 'response_times',
+                timestamp : timestamp.valueOf(),
                 tags : {
                     id : monitor.id,
                     friendlyname : monitor.friendly_name
                 },
                 fields: {
-                    value : rt.value,
-                    time : timestamp.valueOf()
+                    value : rt.value
                 },
             });
         });
 
-        influxdb.writePoints(responseTimePoints)
+        influxdb.writePoints(responseTimePoints, { precision: 'ms' })
             .then(() => {}, error => console.warn(error));
 
         /*********************************************************************
@@ -149,20 +149,20 @@ function processMonitors(monitors){
             const timestamp = moment.unix(log.datetime);
             logTimePoints.push({
                 measurement : "logs",
+                timestamp : timestamp.valueOf(),
                 tags : {
                     id : monitor.id,
                     friendlyname : monitor.friendly_name
                 },
                 fields : {
                     type : log.type,
-                    time : timestamp.valueOf(),
                     reason : (log.reason.code === undefined || log.reason.code == null) ? "" : "" + log.reason.code,
                     reason_detail : (log.reason.detail === undefined || log.reason.detail == null) ? "" : log.reason.detail
                 }
             });
         });
 
-        influxdb.writePoints(logTimePoints)
+        influxdb.writePoints(logTimePoints, { precision: 'ms' })
             .then(() => {}, error => console.warn(error));
     });
 }


### PR DESCRIPTION
The new influx nodejs library has some changes which makes it such that the current implementation of this is not passing-along the timestamps from Uptime Robot properly.

1. The time field must be passed [as a top-level element and not as child of field](https://github.com/node-influx/node-influx/blob/12e5865dbfc992474158c62138f75aef167b704a/test/unit/influx.test.ts#L507)
1. The time field must be named '**timestamp**'
1. Influxdb lib assumes that timestamps passed in to the `writePoints` function are [in nanosecond precision](https://github.com/node-influx/node-influx/blob/master/CHANGELOG.md#2016-10-15-500-alpha1).

This PR should address the above three findings.